### PR TITLE
build: fix configure failure in gcc-14

### DIFF
--- a/dist/config.pkg
+++ b/dist/config.pkg
@@ -144,6 +144,7 @@ EOF
 #include <stdio.h>
 #include <stdlib.h>
 #include <curses.h>
+#include <term.h>
 
 int main(int argc, char *argv[]) {
 	int args[9], error, fd;


### PR DESCRIPTION
```
$ ./configure
[    5s] Checking for curses header file... no
[    5s] !! Can not find curses/tinfo library. The curses/tinfo library is required to compile libt3key.
$ cat config.log
…
.config.c:8:13: error: implicit declaration of function "setupterm";
did you mean ‘set_term’? [-Wimplicit-function-declaration]
```